### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :move_to_item, only: [:show, :edit, :update, :destroy]
   before_action :move_to_edit_update, only: [:edit, :update]
-  before_action :move_to_destroy, only: [:destroy]
+  
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -36,6 +36,11 @@ class ItemsController < ApplicationController
   end
 
   def destroy
+    if current_user.id == @item.user_id
+      redirect_to root_path if @item.destroy
+    else
+      render :show
+    end
   end
 
   private
@@ -52,13 +57,4 @@ class ItemsController < ApplicationController
   def move_to_edit_update
     redirect_to root_path unless current_user.id == @item.user_id
   end
-
-  def move_to_destroy
-    if @item.destroy
-      redirect_to root_path if current_user.id == @item.user_id
-    else
-      render :show
-    end
-  end
-
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,11 +36,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if @item.destroy
-      
-    else
-      render :show
-    end
   end
 
   private
@@ -59,6 +54,11 @@ class ItemsController < ApplicationController
   end
 
   def move_to_destroy
-    redirect_to root_path if current_user.id == @item.user_id
+    if @item.destroy
+      redirect_to root_path if current_user.id == @item.user_id
+    else
+      render :show
+    end
   end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
-  before_action :move_to_item, only: [:show, :edit, :update]
+  before_action :move_to_item, only: [:show, :edit, :update, :destroy]
   before_action :move_to_edit_update, only: [:edit, :update]
 
   def index
@@ -35,7 +35,6 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    @item = Item.find(params[:id])
     if @item.destroy
       redirect_to root_path if current_user.id == @item.user_id
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -39,7 +39,7 @@ class ItemsController < ApplicationController
     if item.destroy
       redirect_to root_path if current_user.id == item.user_id
     else
-      render :destroy
+      render :show
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update]
   before_action :move_to_item, only: [:show, :edit, :update, :destroy]
   before_action :move_to_edit_update, only: [:edit, :update]
+  before_action :move_to_destroy, only: [:destroy]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -36,7 +37,7 @@ class ItemsController < ApplicationController
 
   def destroy
     if @item.destroy
-      redirect_to root_path if current_user.id == @item.user_id
+      
     else
       render :show
     end
@@ -55,5 +56,9 @@ class ItemsController < ApplicationController
 
   def move_to_edit_update
     redirect_to root_path unless current_user.id == @item.user_id
+  end
+
+  def move_to_destroy
+    redirect_to root_path if current_user.id == @item.user_id
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -36,7 +36,11 @@ class ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    item.destroy
+    if item.destroy
+      redirect_to root_path
+    else
+      render :destroy
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -35,9 +35,9 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    if item.destroy
-      redirect_to root_path if current_user.id == item.user_id
+    @item = Item.find(params[:id])
+    if @item.destroy
+      redirect_to root_path if current_user.id == @item.user_id
     else
       render :show
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,7 +34,10 @@ class ItemsController < ApplicationController
     end
   end
 
-  
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+  end
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,7 @@ class ItemsController < ApplicationController
   def destroy
     item = Item.find(params[:id])
     if item.destroy
-      redirect_to root_path
+      redirect_to root_path if current_user.id == item.user_id
     else
       render :destroy
     end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -34,6 +34,7 @@ class ItemsController < ApplicationController
     end
   end
 
+  
 
   private
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,7 +28,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path, method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path, method: :delete, class:"item-destroy" %>
       <% else %>  
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
+  resources :items
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,5 @@ Rails.application.routes.draw do
   devise_for :users
   
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update, :destroy]
 end


### PR DESCRIPTION
# what
商品削除機能を実装いたしました。

# why
ユーザーが間違えて商品を出品した時の削除できるようにするためです。


## テスト動画（出品者のみ商品が正常に削除できること）

以下の３項目を確認いたしました。

（１）ログイン状態の出品者のみ、出品した商品を削除できること
（２）ログイン状態でも出品者以外には、削除ボタンが表示されないこと
（３）ログアウト状態なら、削除ボタンが表示されないこと



（１）ログイン状態の出品者のみ、出品した商品を削除できること

[![Image from Gyazo](https://i.gyazo.com/3e3ac0834d78e94b46228ee6681624fe.gif)](https://gyazo.com/3e3ac0834d78e94b46228ee6681624fe)


（２）ログイン状態でも出品者以外には、削除ボタンが表示されないこと

[![Image from Gyazo](https://i.gyazo.com/a3c34942bb49e77375aecc965345592d.gif)](https://gyazo.com/a3c34942bb49e77375aecc965345592d)


（３）ログアウト状態なら、削除ボタンが表示されないこと

[![Image from Gyazo](https://i.gyazo.com/95d9c7ebd71391abcd434e5aac676516.gif)](https://gyazo.com/95d9c7ebd71391abcd434e5aac676516)